### PR TITLE
Added missing osx_architecture parameters, to be able to build for macOs

### DIFF
--- a/ci/circleci-build-macos.sh
+++ b/ci/circleci-build-macos.sh
@@ -55,6 +55,7 @@ cmake \
   -DCMAKE_INSTALL_PREFIX= \
   -DCMAKE_OSX_DEPLOYMENT_TARGET=10.10 \
   -DOCPN_TARGET_TUPLE="darwin-wx32;10;x86_64" \
+  -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
   ..
 
 if [[ -z "$CI" ]]; then


### PR DESCRIPTION
Hi.

While building locally on macOs, I ran into an error: (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')). For that reason I suggest to add the architecture parameters, as been done for other plugins as well.